### PR TITLE
Lock auto-exposure of camera

### DIFF
--- a/src/com/jwetherell/heart_rate_monitor/HeartRateMonitor.java
+++ b/src/com/jwetherell/heart_rate_monitor/HeartRateMonitor.java
@@ -94,7 +94,17 @@ public class HeartRateMonitor extends Activity {
         wakeLock.acquire();
 
         camera = Camera.open();
-
+        Camera.Parameters parameters = camera.getParameters();
+        if(parameters.getMaxExposureCompensation() != parameters.getMinExposureCompensation()){
+            parameters.setExposureCompensation(0);	
+        }
+        if(parameters.isAutoExposureLockSupported()){
+        	parameters.setAutoExposureLock(true);
+        }
+        if(parameters.isAutoWhiteBalanceLockSupported()){
+        	parameters.setAutoWhiteBalanceLock(true);
+        }
+        camera.setParameters(parameters);
         startTime = System.currentTimeMillis();
     }
 


### PR DESCRIPTION
When my finger touches the camera, the camera always automatically adjust exposure, so the images change regularly on a frequency of about 200Hz. I added some codes to lock AutoExposure, AutoExposureCompensation and AutoWhiteBalance.